### PR TITLE
NOREF Fix bug with year-only dates

### DIFF
--- a/lib/date_component.rb
+++ b/lib/date_component.rb
@@ -39,6 +39,6 @@ class DateComponent
         month = instance_variable_get("@#{pos}_month") || '-'
         day = instance_variable_get("@#{pos}_day")
 
-        "#{year}-#{month}-#{day}".chomp('-')
+        "#{year}-#{month}-#{day}".gsub(/\-+$/, '')
     end
 end

--- a/spec/date_component_spec.rb
+++ b/spec/date_component_spec.rb
@@ -101,5 +101,13 @@ describe DateComponent do
 
             expect(out_date).to eq('2020---01')
         end
+
+        it 'should return an ISO-8601 year if day and month are missing' do
+            @test_date.instance_variable_set(:@start_year, '2020')
+
+            out_date = @test_date.send(:_format_str, 'start')
+
+            expect(out_date).to eq('2020')
+        end
     end
 end


### PR DESCRIPTION
The `date_component` parser was not accurately handling year only dates and returning strings formatted as `2020---`. This was due to a misunderstanding of how `chomp` operated, and which is now replaced with a call to `gsub` which accurately replaces the trailing hyphens