### PR TITLE
SCC-2324 Replace missing to_s

### DIFF
--- a/lib/date_component.rb
+++ b/lib/date_component.rb
@@ -35,7 +35,7 @@ class DateComponent
         $logger.debug 'Parsing date strings from values', { values: @date_values }
         # Split date strings into start/end values and then pivot them into properly arranged arrays
         # e.g. [[1, 2], [3, 4], [5, 6]] to [[1, 3, 5], [2, 4, 6]]
-        date_components = @date_values.map { |v| _extract_date_components v }.transpose
+        date_components = @date_values.map { |v| _extract_date_components v.to_s }.transpose
 
         begin
             start_str = _transform_date_components_to_str date_components[0]

--- a/spec/date_component_spec.rb
+++ b/spec/date_component_spec.rb
@@ -19,7 +19,7 @@ describe DateComponent do
         end
 
         it 'should return a hash containing start and end dates if they are different' do
-            @test_date.instance_variable_set(:@date_values, ['2020', '01-12', '1-31'])
+            @test_date.instance_variable_set(:@date_values, [2020, '01-12', '1-31'])
 
             @test_date.create_strs
 


### PR DESCRIPTION
This is essentially a hot fix because a previous PR removed a necessary `to_s` call to ensure that all date components are strings before being parsed