### PR TITLE
HOTFIX Update swagger documentation endpoint

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -35,7 +35,7 @@ def handle_event(event:, context:)
 
     return create_response(501, 'sierraCheckInCardService only implements GET endpoints') unless method == 'GET'
 
-    if path == '/docs/checkincards'
+    if path == '/docs/check-in-cards'
         load_swagger_docs
     elsif /\S+\/holdings\/check\-in\-cards/.match? path
         fetch_records_and_respond params

--- a/spec/handler_spec.rb
+++ b/spec/handler_spec.rb
@@ -62,7 +62,7 @@ describe 'handler' do
             stubs(:load_swagger_docs).once.returns(200)
 
             res = handle_event(
-                event: { 'path' => '/docs/checkincards', 'httpMethod' => 'GET', 'queryStringParameters' => 'params' },
+                event: { 'path' => '/docs/check-in-cards', 'httpMethod' => 'GET', 'queryStringParameters' => 'params' },
                 context: {}
             )
 


### PR DESCRIPTION
The current path does not match the API gateway configuration, nor does it conform to general standards for API endpoints. This fixes the issue (and is a hotfix because the problem is blocking deployment to the API Gateway).