### PR TITLE
NOREF Fix terraform deployment (for real)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,17 +17,14 @@ jobs:
       script:
         - rake lint
         - rake test
-    - stage: before deploy
-      if: type IN (push) AND (branch = qa OR branch = main)
-      script:
-        - rm -rf vendor
-        - bundle install --without test
     - stage: deploy qa
       if: type IN (push) and branch = qa
       env:
         - AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID_QA
         - AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY_QA
       script:
+        - rm -rf vendor
+        - bundle install --without test
         - terraform -chdir=provisioning/qa init -input=false
         - echo "Deploying to qa"
         - terraform -chdir=provisioning/qa apply -auto-approve -input=false
@@ -37,6 +34,8 @@ jobs:
         - AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID_PRODUCTION
         - AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY_PRODUCTION
       script:
+        - rm -rf vendor
+        - bundle install --without test
         - terraform -chdir=provisioning/production init -input=false
         - echo "Deploying to production"
         - terraform -chdir=provisioning/production apply -auto-approve -input=false


### PR DESCRIPTION
The previous fix did not resolve the issue because I did not understand the relationship between travis "stages". Each stage is provisioned it's own VM, meaning that cleaning the environment in one stage is not carried over to the next. (This seems ineffecient to me, but that's the way it works).

This moves the cleaning commands to each script for the deploy stages. This has the effect of duplicating some code, but as it's only two lines repeated twice, this doesn't seem too bad.